### PR TITLE
feat: Add comprehensive webhook support for inbound emails (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-01-16
+
+### Added
+- **Webhook Support**: Complete webhook payload parsing for inbound emails
+  - `WebhookPayload` type matching official Inbound documentation structure
+  - Support for `email.received` webhook events with nested email data
+  - `WebhookEmailData`, `WebhookParsedData`, and `WebhookCleanedContent` types
+  - `WebhookAddressGroup` and `WebhookAddress` for email address handling
+  - `WebhookAttachment` type for email attachments in webhooks
+  - `ParseWebhookPayload()` function for parsing incoming webhook requests
+  - Helper methods: `GetFromAddress()`, `GetToAddress()`, `GetHeaders()`
+  - Support for both `parsedData` and `cleanedContent` from webhook payloads
+  - Complex header parsing (strings, arrays, objects like DKIM signatures)
+  - Comprehensive webhook parsing tests with edge case coverage
+
+### Technical Details
+- Added `webhook.go` with webhook parsing utilities
+- Added `webhook_test.go` with comprehensive test coverage
+- Updated type definitions to match official Inbound webhook structure
+- Support for flexible date handling (string or Date object)
+- Proper handling of optional fields and null values
+
 ## [0.1.0] - 2024-01-XX
 
 ### Added

--- a/types.go
+++ b/types.go
@@ -559,3 +559,73 @@ type DeleteScheduledEmailResponse struct {
 	Status      string `json:"status"` // 'cancelled'
 	CancelledAt string `json:"cancelled_at"`
 }
+
+// Webhook Payload Types - for incoming email.received webhooks
+type WebhookPayload struct {
+	Event     string              `json:"event"`
+	Timestamp string              `json:"timestamp"`
+	Email     WebhookEmailData    `json:"email"`
+	Endpoint  *WebhookEndpointRef `json:"endpoint,omitempty"`
+}
+
+type WebhookEmailData struct {
+	ID             string                 `json:"id"`
+	MessageID      string                 `json:"messageId"`
+	From           WebhookAddressGroup    `json:"from"`
+	To             WebhookAddressGroup    `json:"to"`
+	Recipient      string                 `json:"recipient"`
+	Subject        string                 `json:"subject"`
+	ReceivedAt     string                 `json:"receivedAt"`
+	ParsedData     WebhookParsedData      `json:"parsedData"`
+	CleanedContent *WebhookCleanedContent `json:"cleanedContent,omitempty"`
+}
+
+type WebhookAddressGroup struct {
+	Text      string           `json:"text"`
+	Addresses []WebhookAddress `json:"addresses"`
+}
+
+type WebhookAddress struct {
+	Name    *string `json:"name"`
+	Address string  `json:"address"`
+}
+
+type WebhookParsedData struct {
+	MessageID   string               `json:"messageId"`
+	Date        any                  `json:"date"` // Can be string or Date object
+	Subject     string               `json:"subject"`
+	From        WebhookAddressGroup  `json:"from"`
+	To          WebhookAddressGroup  `json:"to"`
+	Cc          *WebhookAddressGroup `json:"cc"`
+	Bcc         *WebhookAddressGroup `json:"bcc"`
+	ReplyTo     *WebhookAddressGroup `json:"replyTo"`
+	InReplyTo   *string              `json:"inReplyTo,omitempty"`
+	References  *string              `json:"references,omitempty"`
+	TextBody    string               `json:"textBody"`
+	HTMLBody    string               `json:"htmlBody"`
+	Attachments []WebhookAttachment  `json:"attachments"`
+	Headers     map[string]any       `json:"headers"`
+	Priority    *string              `json:"priority,omitempty"`
+}
+
+type WebhookCleanedContent struct {
+	HTML        string              `json:"html"`
+	Text        string              `json:"text"`
+	HasHTML     bool                `json:"hasHtml"`
+	HasText     bool                `json:"hasText"`
+	Attachments []WebhookAttachment `json:"attachments"`
+	Headers     map[string]any      `json:"headers"`
+}
+
+type WebhookAttachment struct {
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	ContentID   string `json:"contentId"`
+	URL         string `json:"url"`
+}
+
+type WebhookEndpointRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,73 @@
+package inboundgo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// ParseWebhookPayload parses an incoming webhook payload into the WebhookPayload struct
+func ParseWebhookPayload(reader io.Reader) (*WebhookPayload, error) {
+	var payload WebhookPayload
+	decoder := json.NewDecoder(reader)
+	err := decoder.Decode(&payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse webhook payload: %w", err)
+	}
+	return &payload, nil
+}
+
+// GetFromAddress extracts the properly formatted from address from the webhook
+func (w *WebhookPayload) GetFromAddress() string {
+	if len(w.Email.From.Addresses) > 0 {
+		addr := w.Email.From.Addresses[0]
+		if addr.Name != nil && *addr.Name != "" {
+			return fmt.Sprintf("%s <%s>", *addr.Name, addr.Address)
+		}
+		return addr.Address
+	}
+	return ""
+}
+
+// GetToAddress extracts the properly formatted to address from the webhook
+func (w *WebhookPayload) GetToAddress() string {
+	if len(w.Email.To.Addresses) > 0 {
+		addr := w.Email.To.Addresses[0]
+		if addr.Name != nil && *addr.Name != "" {
+			return fmt.Sprintf("%s <%s>", *addr.Name, addr.Address)
+		}
+		return addr.Address
+	}
+	return ""
+}
+
+// GetHeaders converts the headers from the webhook format to a standard map[string][]string format
+func (w *WebhookPayload) GetHeaders() map[string][]string {
+	headers := make(map[string][]string)
+	for k, v := range w.Email.ParsedData.Headers {
+		switch val := v.(type) {
+		case string:
+			headers[k] = []string{val}
+		case []string:
+			headers[k] = val
+		case []any:
+			var strSlice []string
+			for _, item := range val {
+				if str, ok := item.(string); ok {
+					strSlice = append(strSlice, str)
+				}
+			}
+			if len(strSlice) > 0 {
+				headers[k] = strSlice
+			}
+		case map[string]any:
+			// Handle complex header structures like dkim-signature
+			if text, ok := val["text"].(string); ok {
+				headers[k] = []string{text}
+			} else if value, ok := val["value"].(string); ok {
+				headers[k] = []string{value}
+			}
+		}
+	}
+	return headers
+}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,264 @@
+package inboundgo
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseWebhookPayload(t *testing.T) {
+	payload := `{
+  "event": "email.received",
+  "timestamp": "2025-09-16T16:47:50.163Z",
+  "email": {
+    "id": "7U6TcAy-16qmzu297IVoL",
+    "messageId": "<test-yaZbgt70Z4J6XKIiAAEvZ@mail.inbound.new>",
+    "from": {
+      "text": "Inbound Test <test@example.com>",
+      "addresses": [
+        {
+          "name": "Inbound Test",
+          "address": "test@example.com"
+        }
+      ]
+    },
+    "to": {
+      "text": "Test Recipient <test@yourdomain.com>",
+      "addresses": [
+        {
+          "name": null,
+          "address": "test@yourdomain.com"
+        }
+      ]
+    },
+    "recipient": "test@yourdomain.com",
+    "subject": "Test Email - Inbound Email Service",
+    "receivedAt": "2025-09-16T16:47:50.163Z",
+    "parsedData": {
+      "messageId": "<test-yaZbgt70Z4J6XKIiAAEvZ@mail.inbound.new>",
+      "date": "2025-09-16T16:47:50.163Z",
+      "subject": "Test Email - Inbound Email Service",
+      "from": {
+        "text": "Inbound Test <test@example.com>",
+        "addresses": [
+          {
+            "name": "Inbound Test",
+            "address": "test@example.com"
+          }
+        ]
+      },
+      "to": {
+        "text": "Test Recipient <test@yourdomain.com>",
+        "addresses": [
+          {
+            "name": null,
+            "address": "test@yourdomain.com"
+          }
+        ]
+      },
+      "cc": null,
+      "bcc": null,
+      "replyTo": null,
+      "textBody": "This is a test email.\nRendered for webhook testing.",
+      "htmlBody": "<div><p>This is a test email.</p><p><strong>Rendered for webhook testing.</strong></p></div>",
+      "attachments": [],
+      "headers": {
+        "received": [
+          "from test-mta.inbound.new",
+          "by test-mx.google.com"
+        ],
+        "received-spf": "pass",
+        "dkim-signature": {
+          "value": "v=1",
+          "params": {
+            "a": "rsa-sha256",
+            "d": "example.com"
+          }
+        }
+      }
+    },
+    "cleanedContent": {
+      "html": "<div><p>This is a test email.</p><p><strong>Rendered for webhook testing.</strong></p></div>",
+      "text": "This is a test email.\nRendered for webhook testing.",
+      "hasHtml": true,
+      "hasText": true,
+      "attachments": [],
+      "headers": {}
+    }
+  },
+  "endpoint": {
+    "id": "LHbWZ1iEOofDXlViXWsDH",
+    "name": "6979012cd152 E",
+    "type": "webhook"
+  }
+}`
+
+	webhook, err := ParseWebhookPayload(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Failed to parse webhook payload: %v", err)
+	}
+
+	// Test basic webhook fields
+	if webhook.Event != "email.received" {
+		t.Errorf("Expected event 'email.received', got '%s'", webhook.Event)
+	}
+
+	if webhook.Timestamp != "2025-09-16T16:47:50.163Z" {
+		t.Errorf("Expected timestamp '2025-09-16T16:47:50.163Z', got '%s'", webhook.Timestamp)
+	}
+
+	// Test email fields
+	if webhook.Email.ID != "7U6TcAy-16qmzu297IVoL" {
+		t.Errorf("Expected email ID '7U6TcAy-16qmzu297IVoL', got '%s'", webhook.Email.ID)
+	}
+
+	if webhook.Email.MessageID != "<test-yaZbgt70Z4J6XKIiAAEvZ@mail.inbound.new>" {
+		t.Errorf("Expected message ID '<test-yaZbgt70Z4J6XKIiAAEvZ@mail.inbound.new>', got '%s'", webhook.Email.MessageID)
+	}
+
+	if webhook.Email.Subject != "Test Email - Inbound Email Service" {
+		t.Errorf("Expected subject 'Test Email - Inbound Email Service', got '%s'", webhook.Email.Subject)
+	}
+
+	if webhook.Email.Recipient != "test@yourdomain.com" {
+		t.Errorf("Expected recipient 'test@yourdomain.com', got '%s'", webhook.Email.Recipient)
+	}
+
+	// Test helper methods
+	fromAddr := webhook.GetFromAddress()
+	if fromAddr != "Inbound Test <test@example.com>" {
+		t.Errorf("Expected from address 'Inbound Test <test@example.com>', got '%s'", fromAddr)
+	}
+
+	toAddr := webhook.GetToAddress()
+	if toAddr != "test@yourdomain.com" {
+		t.Errorf("Expected to address 'test@yourdomain.com', got '%s'", toAddr)
+	}
+
+	// Test parsed data
+	if webhook.Email.ParsedData.TextBody != "This is a test email.\nRendered for webhook testing." {
+		t.Errorf("Expected text body 'This is a test email.\\nRendered for webhook testing.', got '%s'", webhook.Email.ParsedData.TextBody)
+	}
+
+	if webhook.Email.ParsedData.HTMLBody != "<div><p>This is a test email.</p><p><strong>Rendered for webhook testing.</strong></p></div>" {
+		t.Errorf("Expected HTML body '<div><p>This is a test email.</p><p><strong>Rendered for webhook testing.</strong></p></div>', got '%s'", webhook.Email.ParsedData.HTMLBody)
+	}
+
+	// Test cleaned content
+	if webhook.Email.CleanedContent == nil {
+		t.Error("Expected cleaned content to be present")
+	} else {
+		if webhook.Email.CleanedContent.Text != "This is a test email.\nRendered for webhook testing." {
+			t.Errorf("Expected cleaned content text 'This is a test email.\\nRendered for webhook testing.', got '%s'", webhook.Email.CleanedContent.Text)
+		}
+
+		if webhook.Email.CleanedContent.HTML != "<div><p>This is a test email.</p><p><strong>Rendered for webhook testing.</strong></p></div>" {
+			t.Errorf("Expected cleaned content HTML '<div><p>This is a test email.</p><p><strong>Rendered for webhook testing.</strong></p></div>', got '%s'", webhook.Email.CleanedContent.HTML)
+		}
+
+		if !webhook.Email.CleanedContent.HasHTML {
+			t.Error("Expected cleaned content to have HTML")
+		}
+
+		if !webhook.Email.CleanedContent.HasText {
+			t.Error("Expected cleaned content to have text")
+		}
+	}
+
+	// Test headers parsing
+	headers := webhook.GetHeaders()
+	if len(headers["received"]) != 2 {
+		t.Errorf("Expected 2 received headers, got %d", len(headers["received"]))
+	}
+
+	if headers["received-spf"][0] != "pass" {
+		t.Errorf("Expected received-spf 'pass', got '%s'", headers["received-spf"][0])
+	}
+
+	// Test complex header parsing (dkim-signature as object)
+	if _, exists := headers["dkim-signature"]; !exists {
+		t.Error("Expected dkim-signature header to be parsed")
+	}
+
+	// Test endpoint
+	if webhook.Endpoint == nil {
+		t.Error("Expected endpoint to be present")
+	} else {
+		if webhook.Endpoint.ID != "LHbWZ1iEOofDXlViXWsDH" {
+			t.Errorf("Expected endpoint ID 'LHbWZ1iEOofDXlViXWsDH', got '%s'", webhook.Endpoint.ID)
+		}
+
+		if webhook.Endpoint.Name != "6979012cd152 E" {
+			t.Errorf("Expected endpoint name '6979012cd152 E', got '%s'", webhook.Endpoint.Name)
+		}
+
+		if webhook.Endpoint.Type != "webhook" {
+			t.Errorf("Expected endpoint type 'webhook', got '%s'", webhook.Endpoint.Type)
+		}
+	}
+}
+
+func TestGetFromAddressWithoutName(t *testing.T) {
+	payload := `{
+  "event": "email.received",
+  "timestamp": "2025-09-16T16:47:50.163Z",
+  "email": {
+    "from": {
+      "text": "test@example.com",
+      "addresses": [
+        {
+          "name": null,
+          "address": "test@example.com"
+        }
+      ]
+    },
+    "parsedData": {
+      "headers": {}
+    }
+  }
+}`
+
+	webhook, err := ParseWebhookPayload(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Failed to parse webhook payload: %v", err)
+	}
+
+	fromAddr := webhook.GetFromAddress()
+	if fromAddr != "test@example.com" {
+		t.Errorf("Expected from address 'test@example.com' (without name), got '%s'", fromAddr)
+	}
+}
+
+func TestGetAddressesEmpty(t *testing.T) {
+	payload := `{
+  "event": "email.received",
+  "timestamp": "2025-09-16T16:47:50.163Z",
+  "email": {
+    "from": {
+      "text": "",
+      "addresses": []
+    },
+    "to": {
+      "text": "",
+      "addresses": []
+    },
+    "parsedData": {
+      "headers": {}
+    }
+  }
+}`
+
+	webhook, err := ParseWebhookPayload(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Failed to parse webhook payload: %v", err)
+	}
+
+	fromAddr := webhook.GetFromAddress()
+	if fromAddr != "" {
+		t.Errorf("Expected empty from address, got '%s'", fromAddr)
+	}
+
+	toAddr := webhook.GetToAddress()
+	if toAddr != "" {
+		t.Errorf("Expected empty to address, got '%s'", toAddr)
+	}
+}


### PR DESCRIPTION
- Add WebhookPayload types matching official Inbound documentation
- Support email.received webhook events with nested data structures
- Add ParseWebhookPayload() function for parsing webhook requests
- Add helper methods: GetFromAddress(), GetToAddress(), GetHeaders()
- Support both parsedData and cleanedContent from webhook payloads
- Handle complex header parsing (strings, arrays, objects)
- Add comprehensive webhook parsing tests with edge cases
- Update types to match official webhook structure
- Support flexible date handling and optional fields

This enables applications to properly parse Inbound webhook payloads instead of relying on custom parsing logic.


Amp-Thread-ID: https://ampcode.com/threads/T-116df522-92b1-4a32-9d68-11ba56225ea2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added inbound webhook support for email.received events, including JSON payload parsing.
  - Helper accessors for From/To addresses and normalized headers.
  - Supports parsed and cleaned content, attachments, endpoint info, flexible date formats, and optional/null fields.

- Tests
  - Comprehensive unit tests for payload parsing, headers (multi-value/object forms), cleaned content flags, attachments, endpoint details, and edge cases (missing names/addresses).

- Documentation
  - Updated changelog with 0.2.0 release entry highlighting webhook support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->